### PR TITLE
[chore] Activity API 수정(#LYC-66)

### DIFF
--- a/src/main/java/com/Lycle/Server/controller/ActivityController.java
+++ b/src/main/java/com/Lycle/Server/controller/ActivityController.java
@@ -1,7 +1,7 @@
 package com.Lycle.Server.controller;
 
 import com.Lycle.Server.config.auth.UserPrincipal;
-import com.Lycle.Server.dto.Activity.FinishActivityDto;
+import com.Lycle.Server.dto.Activity.RequestActivityDto;
 import com.Lycle.Server.dto.BasicResponse;
 import com.Lycle.Server.service.ActivityService;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +17,7 @@ import java.util.Collections;
 public class ActivityController {
     private final ActivityService activityService;
 
+    /*
     //운동 시작 시간 기록
     @PostMapping("/user/activity")
     public ResponseEntity<BasicResponse> startActivity(Authentication authentication){
@@ -29,16 +30,18 @@ public class ActivityController {
                 .build();
         return new ResponseEntity<>(activityResponse,activityResponse.getHttpStatus());
     }
+     */
 
-    //운동 중단 시간 기록
-    @PutMapping("/user/activity")
-    public ResponseEntity<BasicResponse> finishActivity(@RequestBody FinishActivityDto finishActivityDto){
+    //챌린지 기록
+    @PostMapping("/user/activity")
+    public ResponseEntity<BasicResponse> saveActivity(Authentication authentication, @RequestBody RequestActivityDto requestActivityDto){
+        UserPrincipal userPrincipal = (UserPrincipal) authentication;
         BasicResponse activityResponse = BasicResponse.builder()
                 .code(HttpStatus.CREATED.value())
                 .httpStatus(HttpStatus.CREATED)
                 .message("챌린지 종료 시간이 기록되었습니다.")
                 .count(1)
-                .result(Collections.singletonList(activityService.finishActivity(finishActivityDto)))
+                .result(Collections.singletonList(activityService.saveActivity(userPrincipal.getId() ,requestActivityDto)))
                 .build();
         return new ResponseEntity<>(activityResponse,activityResponse.getHttpStatus());
     }

--- a/src/main/java/com/Lycle/Server/domain/Activity.java
+++ b/src/main/java/com/Lycle/Server/domain/Activity.java
@@ -41,12 +41,4 @@ public class Activity extends BaseTimeEntity {
         this.rewardChecked = rewardChecked;
     }
 
-    public void update(String category, String activityTime ,boolean finishChecked, boolean rewardChecked){
-        this.category = category;
-        this.activityTime = activityTime;
-        this.finishChecked = finishChecked;
-        this.rewardChecked = rewardChecked;
-    }
-
-
 }

--- a/src/main/java/com/Lycle/Server/dto/Activity/RequestActivityDto.java
+++ b/src/main/java/com/Lycle/Server/dto/Activity/RequestActivityDto.java
@@ -6,16 +6,14 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 @Getter
-public class FinishActivityDto {
-    private Long id;
+public class RequestActivityDto {
     private String category;
     private String activityTime;
     private boolean finishChecked;
     private boolean rewardChecked;
 
     @Builder
-    public FinishActivityDto(Long id,String category,String activityTime ,boolean finishChecked, boolean rewardChecked){
-        this.id = id;
+    public RequestActivityDto(String category, String activityTime , boolean finishChecked, boolean rewardChecked){
         this.category = category;
         this.activityTime = activityTime;
         this.finishChecked = finishChecked;

--- a/src/main/java/com/Lycle/Server/service/ActivityService.java
+++ b/src/main/java/com/Lycle/Server/service/ActivityService.java
@@ -2,15 +2,12 @@ package com.Lycle.Server.service;
 
 import com.Lycle.Server.domain.Activity;
 import com.Lycle.Server.domain.jpa.ActivityRepository;
-import com.Lycle.Server.dto.Activity.FinishActivityDto;
+import com.Lycle.Server.dto.Activity.RequestActivityDto;
 import com.Lycle.Server.dto.Activity.SearchActivityWrapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
 import java.util.List;
-import java.util.StringTokenizer;
 
 @Service
 @RequiredArgsConstructor
@@ -18,21 +15,14 @@ public class ActivityService {
     private final ActivityRepository activityRepository;
 
     @Transactional
-    public Long startActivity(Long id){
-       return activityRepository.save(Activity.builder()
-               .userId(id)
-               .build()).getId();
-    }
-
-    @Transactional
-    public Activity finishActivity(FinishActivityDto finishActivityDto){
-        Long id = finishActivityDto.getId();
-        Activity activity = activityRepository.findById(id).orElseThrow(
-                () ->new IllegalArgumentException("존재 하지 않는 챌린지 입니다."));
-
-        activity.update(finishActivityDto.getCategory(), finishActivityDto.getActivityTime(),
-                finishActivityDto.isFinishChecked(), finishActivityDto.isRewardChecked());
-        return activity;
+    public Long saveActivity(Long userId, RequestActivityDto requestActivityDto){
+        return activityRepository.save(Activity.builder()
+                        .userId(userId)
+                        .category(requestActivityDto.getCategory())
+                        .activityTime(requestActivityDto.getActivityTime())
+                        .finishChecked(requestActivityDto.isFinishChecked())
+                        .rewardChecked(requestActivityDto.isRewardChecked())
+                .build()).getId();
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
- 챌린지 종료 시 한 번에 챌린지에 관한 정보가 저장되도록 수정 